### PR TITLE
Adding SVP DEWENet Support

### DIFF
--- a/Lib/svpelab/das_dewetron.py
+++ b/Lib/svpelab/das_dewetron.py
@@ -1,0 +1,163 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Questions can be directed to support@sunspec.org
+"""
+
+import os
+from device_das_dewetron import Device
+from das import DAS as MDAS
+
+dewetron_info = {
+    'name': os.path.splitext(os.path.basename(__file__))[0],
+    'mode': 'Dewetron'
+}
+
+def das_info():
+    return dewetron_info
+
+def params(info, group_name=None):
+    gname = lambda name: group_name + '.' + name
+    pname = lambda name: group_name + '.' + GROUP_NAME + '.' + name
+    mode = dewetron_info['mode']
+    info.param_add_value(gname('mode'), mode)
+    info.param_group(gname(GROUP_NAME), label='%s Parameters' % mode,
+                     active=gname('mode'), active_value=mode, glob=True)
+    info.param(pname('comm'), label='Communications Interface', default='Network', values=['Network'])
+    info.param(pname('ip_addr'), label='DEWESoft NET IP Address',
+               active=pname('comm'), active_value=['Network'], default='127.0.0.1')
+    info.param(pname('ip_port'), label='DEWESoft NET Port',
+               active=pname('comm'), active_value=['Network'], default=8999)
+
+    info.param(pname('deweproxy_ip_addr'), label='Binary Server IP Address',
+               active=pname('comm'), active_value=['Network'], default='127.0.0.1')
+    info.param(pname('deweproxy_ip_port'), label='Binary Server Port',
+               active=pname('comm'), active_value=['Network'], default=9000)
+
+    info.param(pname('sample_interval'), label='SVP Sample Interval (ms)', default=1000)
+    info.param(pname('sample_interval_dewe'), label='Dewetron Sample Frequency (Hz)', default=5000)
+
+    info.param(pname('AC_VRMS_1'), label='L1 Voltage RMS (V)', default='Va')
+    info.param(pname('AC_VRMS_2'), label='L2 Voltage RMS (V)', default='Vb')
+    info.param(pname('AC_VRMS_3'), label='L3 Voltage RMS (V)', default='Vc')
+    info.param(pname('AC_IRMS_1'), label='L1 Current RMS (A)', default='Ia')
+    info.param(pname('AC_IRMS_2'), label='L2 Current RMS (A)', default='Ib')
+    info.param(pname('AC_IRMS_3'), label='L3 Current RMS (A)', default='Ic')
+    info.param(pname('AC_FREQ_1'), label='L1 Frequency (Hz)', default='F')
+    info.param(pname('AC_FREQ_2'), label='L2 Frequency (Hz)', default='F')
+    info.param(pname('AC_FREQ_3'), label='L3 Frequency (Hz)', default='F')
+    info.param(pname('AC_P_1'), label='L1 Active Power (W)', default='Pa')
+    info.param(pname('AC_P_2'), label='L2 Active Power (W)', default='Pb')
+    info.param(pname('AC_P_3'), label='L3 Active Power (W)', default='Pc')
+    info.param(pname('AC_S_1'), label='L1 Apparent Power (VA)', default='Sa')
+    info.param(pname('AC_S_2'), label='L2 Apparent Power (VA)', default='Sb')
+    info.param(pname('AC_S_3'), label='L3 Apparent Power (VA)', default='Sc')
+    info.param(pname('AC_Q_1'), label='L1 Reactive Power (Var)', default='Qa')
+    info.param(pname('AC_Q_2'), label='L2 Reactive Power (Var)', default='Qb')
+    info.param(pname('AC_Q_3'), label='L3 Reactive Power (Var)', default='Qc')
+    info.param(pname('AC_PF_1'), label='L1 Power factor', default='PFa')
+    info.param(pname('AC_PF_2'), label='L2 Power factor', default='PFb')
+    info.param(pname('AC_PF_3'), label='L3 Power factor', default='PFc')
+
+
+
+    info.param(pname('DC_V'), label='DC Voltage (V)', default='Vdc')
+    info.param(pname('DC_I'), label='DC Current (A)', default='Idc')
+    info.param(pname('DC_P'), label='DC Power (W)', default='Pdc')
+
+
+
+
+
+
+GROUP_NAME = 'dewetron'
+
+
+class DAS(MDAS):
+    """
+    Template for data acquisition (DAS) implementations. This class can be used as a base class or
+    independent data acquisition classes can be created containing the methods contained in this class.
+    """
+
+    def __init__(self, ts, group_name, points=None, sc_points=None):
+        MDAS.__init__(self, ts, group_name, points=points, sc_points=sc_points)
+
+        self.params['ts'] = ts
+
+        self.params['sample_interval'] = self._param_value('sample_interval')
+        self.sample_interval = self.params['sample_interval']
+
+        self.params['ip_addr'] = self._param_value('ip_addr')
+        self.params['ipport'] = self._param_value('ip_port')
+
+        self.params['deweproxy_ip_addr'] = self._param_value('deweproxy_ip_addr')
+        self.params['deweproxy_ip_port'] = self._param_value('deweproxy_ip_port')
+
+
+        self.params['AC_VRMS_1'] = self._param_value('AC_VRMS_1')
+        self.params['AC_VRMS_2'] = self._param_value('AC_VRMS_2')
+        self.params['AC_VRMS_3'] = self._param_value('AC_VRMS_3')
+        self.params['AC_IRMS_1'] = self._param_value('AC_IRMS_1')
+        self.params['AC_IRMS_2'] = self._param_value('AC_IRMS_2')
+        self.params['AC_IRMS_3'] = self._param_value('AC_IRMS_3')
+        self.params['AC_FREQ_1'] = self._param_value('AC_FREQ_1')
+        self.params['AC_FREQ_2'] = self._param_value('AC_FREQ_2')
+        self.params['AC_FREQ_3'] = self._param_value('AC_FREQ_3')
+        self.params['AC_P_1'] = self._param_value('AC_P_1')
+        self.params['AC_P_2'] = self._param_value('AC_P_2')
+        self.params['AC_P_3'] = self._param_value('AC_P_3')
+        self.params['AC_S_1'] = self._param_value('AC_S_1')
+        self.params['AC_S_2'] = self._param_value('AC_S_2')
+        self.params['AC_S_3'] = self._param_value('AC_S_3')
+        self.params['AC_Q_1'] = self._param_value('AC_Q_1')
+        self.params['AC_Q_2'] = self._param_value('AC_Q_2')
+        self.params['AC_Q_3'] = self._param_value('AC_Q_3')
+        self.params['AC_PF_1'] = self._param_value('AC_PF_1')
+        self.params['AC_PF_2'] = self._param_value('AC_PF_2')
+        self.params['AC_PF_3'] = self._param_value('AC_PF_3')
+        self.params['DC_V'] = self._param_value('DC_V')
+        self.params['DC_I'] = self._param_value('DC_I')
+        self.params['DC_P'] = self._param_value('DC_P')
+        self.params['sample_interval_dewe'] = self._param_value('sample_interval_dewe')
+
+
+
+        self.device = Device(self.params)
+        self.data_points = self.device.data_points
+
+        # initialize soft channel points
+        self._init_sc_points()
+
+    def _param_value(self, name):
+        return self.ts.param_value(self.group_name + '.' + GROUP_NAME + '.' + name)
+
+
+if __name__ == "__main__":
+
+    pass

--- a/Lib/svpelab/device_das_dewetron.py
+++ b/Lib/svpelab/device_das_dewetron.py
@@ -1,0 +1,383 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Questions can be directed to support@sunspec.org
+"""
+
+import time
+from collections import OrderedDict
+import datetime
+
+import numpy as np
+
+try:
+    import dewenetcontroller.dewenetcontroller as dewe
+except Exception, e:
+    print('Missing dewecontroller. %s' % e)
+
+
+
+
+"""
+This is a really bad hack! 
+"""
+data_points = [  # 3 phase
+                'TIME',
+                'DC_V',
+                'DC_I',
+                'AC_VRMS_1',
+                'AC_VRMS_2',
+                'AC_VRMS_3',
+                'AC_IRMS_1',
+                'AC_IRMS_2',
+                'AC_IRMS_3',
+                'DC_P',
+                'AC_S_1',
+                'AC_S_2',
+                'AC_S_3',
+                'AC_P_1',
+                'AC_P_2',
+                'AC_P_3',
+                'AC_Q_1',
+                'AC_Q_2',
+                'AC_Q_3',
+                'AC_FREQ_1',
+                'AC_FREQ_2',
+                'AC_FREQ_3',
+                'AC_PF_1',
+                'AC_PF_2',
+                'AC_PF_3',
+                'TRIG',
+                'TRIG_GRID'
+            ]
+
+
+
+dewe_channelmap = OrderedDict([
+    ('TIME', None),
+    ('AC_VRMS_1', 'Va'),
+    ('AC_IRMS_1', 'Ia'),
+    ('AC_P_1', 'Pa'),
+    ('AC_S_1', 'Sa'),
+    ('AC_Q_1', 'Qa'),
+    ('AC_PF_1', 'PFa'),
+    ('AC_FREQ_1', 'F'),
+    ('AC_VRMS_2', 'Vb'),
+    ('AC_IRMS_2', 'Ib'),
+    ('AC_P_2', 'Pb'),
+    ('AC_S_2', 'Sb'),
+    ('AC_Q_2', 'Qb'),
+    ('AC_PF_2', 'PFb'),
+    ('AC_FREQ_2', 'F'),
+    ('AC_VRMS_3', 'Vc'),
+    ('AC_IRMS_3', 'Ic'),
+    ('AC_P_3', 'Pc'),
+    ('AC_S_3', 'Sc'),
+    ('AC_Q_3', 'Qc'),
+    ('AC_PF_3', 'PFc'),
+    ('AC_FREQ_3', 'F'),
+    ('DC_V', 'Vdc'),
+    ('DC_I', 'Idc'),
+    ('DC_P', 'Pdc'),
+    ('TRIG', None),
+    ('TRIG_GRID', None)
+])
+
+
+deweResults = OrderedDict()
+
+
+def update_value(channel_name, timestamp, value):
+    ts_m = (np.float64(timestamp.strftime('%M.0'))*60)*1000
+    ts_us = np.longlong(ts_m+np.float64(timestamp.strftime('%S.%f'))*1000)
+
+    for k in dewe_channelmap.keys():
+        if dewe_channelmap[k]:
+            if dewe_channelmap[k] in channel_name:
+                try:
+                    deweResults[k]
+                except:
+                    deweResults[k] = []
+                deweResults[k].append( (ts_us, value) )
+
+class Device(object):
+
+    def __logevent__(self, msg):
+        if self.ts:
+            self.ts.log(msg)
+        else:
+            print '%s' % msg
+
+
+    def __init__(self, params=None):
+        if not params:
+            raise ValueError('Params can not be None for this module!')
+
+
+        self.deweDevice = None
+
+        self.params = params
+
+
+        try:
+            self.dewehost = self.params['ip_addr']
+            self.deweport = self.params['ipport']
+            self.sample_interval = self.params['sample_interval']
+        except:
+            raise ValueError('Minimum required paramters were not supplied!')
+
+
+        try:
+            global dewe_channelmap
+            dewe_channelmap['AC_VRMS_1'] = self.params['AC_VRMS_1']
+            dewe_channelmap['AC_VRMS_2'] = self.params['AC_VRMS_2']
+            dewe_channelmap['AC_VRMS_3'] = self.params['AC_VRMS_3']
+            dewe_channelmap['AC_IRMS_1'] = self.params['AC_IRMS_1']
+            dewe_channelmap['AC_IRMS_2'] = self.params['AC_IRMS_2']
+            dewe_channelmap['AC_IRMS_3'] = self.params['AC_IRMS_3']
+            dewe_channelmap['AC_FREQ_1'] = self.params['AC_FREQ_1']
+            dewe_channelmap['AC_FREQ_2'] = self.params['AC_FREQ_2']
+            dewe_channelmap['AC_FREQ_3'] = self.params['AC_FREQ_3']
+            dewe_channelmap['AC_P_1'] = self.params['AC_P_1']
+            dewe_channelmap['AC_P_2'] = self.params['AC_P_2']
+            dewe_channelmap['AC_P_3'] = self.params['AC_P_3']
+            dewe_channelmap['AC_S_1'] = self.params['AC_S_1']
+            dewe_channelmap['AC_S_2'] = self.params['AC_S_2']
+            dewe_channelmap['AC_S_3'] = self.params['AC_S_3']
+            dewe_channelmap['AC_Q_1'] = self.params['AC_Q_1']
+            dewe_channelmap['AC_Q_2'] = self.params['AC_Q_2']
+            dewe_channelmap['AC_Q_3'] = self.params['AC_Q_3']
+            dewe_channelmap['DC_V'] = self.params['DC_V']
+            dewe_channelmap['DC_I'] = self.params['DC_I']
+            dewe_channelmap['DC_P'] = self.params['DC_P']
+            dewe_channelmap['AC_PF_1'] = self.params['AC_PF_1']
+            dewe_channelmap['AC_PF_2'] = self.params['AC_PF_2']
+            dewe_channelmap['AC_PF_3'] = self.params['AC_PF_3']
+            dewe_channelmap['TIME'] = None
+            dewe_channelmap['TRIG'] = None
+            dewe_channelmap['TRIG_GRID'] = None
+
+            self.deweproxyhost = self.params['deweproxy_ip_addr']
+            self.deweproxyport = self.params['deweproxy_ip_port']
+
+        except Exception, e:
+            self.deweproxyhost = '127.0.0.1'
+            self.deweproxyport = 9000
+            print 'Using default map'
+
+
+        try:
+            self.sampling_interval_dewe = self.params['sample_interval_dewe']
+        except:
+            self.sampling_interval_dewe = None
+
+
+        try:
+            self.ts = self.params['ts']
+        except:
+            self.ts = None
+
+        self.__logevent__('DEWESoft NET Plugin Initialized!.')
+
+        try:
+            self.__logger__ = self.params['logger']
+        except:
+            self.__logger__ = None
+
+        self.channellist = []
+
+        for k in dewe_channelmap.keys():
+            if dewe_channelmap[k] is not None:
+                if dewe_channelmap[k] not in self.channellist:
+                    self.channellist.append(dewe_channelmap[k])
+
+
+        self.data_points = list(data_points)
+
+        self.__logevent__(self.data_points)
+
+        self.points = None
+        self.point_indexes = []
+
+             # waveform settings
+        self.wfm_sample_rate = None
+        self.wfm_pre_trigger = None
+        self.wfm_post_trigger = None
+        self.wfm_trigger_level = None
+        self.wfm_trigger_cond = None
+        self.wfm_trigger_channel = None
+        self.wfm_timeout = None
+        self.wfm_channels = None
+        self.wfm_capture_name = None
+
+        self.numberOfSamples = None
+        self.triggerOffset = None
+        self.decimation = 1
+        self.captureSettings = None
+        self.triggerSettings = None
+        self.channelSettings = None
+
+        # regular python list is used for data buffer
+        self.capturedDataBuffer = []
+        self.time_vector = None
+        self.wfm_data = None
+        self.signalsNames = None
+        self.analog_channels = []
+        self.digital_channels = []
+        self.subsampling_rate = None
+
+
+
+        """
+        Why is .open() not handled at toplevel?
+        """
+        self.open()
+
+    def info(self):
+        if self.deweDevice:
+            return self.deweDevice.get_dewe_information()
+        else:
+            raise ValueError("Not connected to DAS - open() was not called prior")
+
+    def open(self):
+        if not self.deweDevice:
+            self.__logevent__('Starting connection to local DEWESoft NET Instance.')
+            try:
+                self.deweDevice = dewe.DeweNetController(logger=self.__logger__)
+                self.deweDevice.connect_to_dewe(dewe_ip=self.dewehost, dewe_port=int(self.deweport),
+                                           client_server_ip=self.deweproxyhost, client_server_port=int(self.deweproxyport),
+                                           list_of_channels=self.channellist, samplerate=self.sampling_interval_dewe)
+
+                self.deweDevice.add_update_value_handler(update_value, channels=self.channellist)
+
+                self.deweDevice.start_dewe_measurement()
+
+            except Exception, e:
+                self.__logevent__('Error on establishing connection to dewe! [%s]' % e)
+                raise
+
+        return self.deweDevice
+
+
+    def close(self):
+        if self.deweDevice:
+            self.deweDevice.stop_dewe_measurement()
+            self.deweDevice.disconnect_from_dewe()
+            self.deweDevice = None
+
+        return self.deweDevice
+
+
+    def data_capture(self, enable=True):
+        """todo: """
+        pass
+
+    def data_read(self):
+        if self.deweDevice:
+            """For Later dict support:
+            retry = 0
+            e = datetime.datetime.now()
+            while True:
+                data = {}
+                try:
+                    data['TIME'] = time.time()
+                    data['TRIG'] = 0
+                    data['TRIG_GRID'] = 0
+                    for i in deweResults.keys():
+                        data[i] = deweResults[i][-1][1]
+
+                    self.__logevent__(data)
+                    return data
+                except Exception, e:
+                    self.__logevent__(e)
+            """
+            while True:
+                data = []
+                try:
+                    data.append(time.time())        #Channle TIME
+                    for i in data_points:
+
+                        if dewe_channelmap[i]:
+                            data.append(deweResults[i][-1][1])
+                    data.append(0)                  #channel TRIG
+                    data.append(0)                  #channel TRIG_GRID
+                    return data
+                except Exception, e:
+                    pass
+        else:
+            raise ValueError("Not connected to DAS - open() was not called prior")
+
+
+
+
+
+
+
+    def waveform_config(self, params):
+        pass
+
+    def waveform_capture(self, enable=True, sleep=None):
+        pass
+
+    def waveform_status(self):
+        pass
+
+    def waveform_force_trigger(self):
+        """
+        Create trigger event with provided value.
+        """
+        pass
+
+    def waveform_capture_dataset(self):
+        pass
+
+
+if __name__ == "__main__":
+
+
+    params = {}
+    params['ip_addr'] = '127.0.0.1'
+    params['ipport'] = 8999
+    params['sample_interval'] = 1000
+    params['sample_interval_dewe'] = 10000
+
+
+
+
+    d = Device(params=params)
+
+    d.open()
+    count = 0
+    while True:
+        count +=1
+        time.sleep(0.5)
+        print d.data_read()
+        if count > 50: break
+    d.close()
+

--- a/Lib/svpelab/dewenetcontroller/__init__.py
+++ b/Lib/svpelab/dewenetcontroller/__init__.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+
+
+""" DeweNetController
+
+Package Description
+
+"""
+# pylint disable=F0401
+# flake8: noqa
+
+__version__ = '1.0.3'
+
+__all__ = ['dewenetcontroller']
+
+from .dewenetcontroller import DeweNetController
+from .dewenet_client import DeweNetClientException

--- a/Lib/svpelab/dewenetcontroller/dewenet_client.py
+++ b/Lib/svpelab/dewenetcontroller/dewenet_client.py
@@ -1,0 +1,956 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+
+
+
+
+
+
+
+
+
+
+"""DeweNetControllerClient module for remote control purposes of the DeweSoft
+
+This module implements the remote control for the communication with the
+DeweSoft measurement software. Therefore the class DeweNetControllerClient is
+used. This module also implements the used exceptions.
+
+
+Command reference (DEWESoft NET protocol version 4) from DeweSoft Net Interface
+Manual
+
+Each command has to have New line suffix (0x13 + 0x10). Commands in brackets
+can only be sent in control mode.
+
++-------------------+----------------------------------------------------------+
+| Command           | Description                                              |
++===================+==========================================================+
+| GETVERSION        | returns DEWESoft version                                 |
++-------------------+----------------------------------------------------------+
+| GETINTFVERSION    | returns DEWESoft NET protocol version                    |
++-------------------+----------------------------------------------------------+
+| GETDATETIME       | returns current time on measurement unit                 |
++-------------------+----------------------------------------------------------+
+| GETMODE           | returns current operation mode (control or view)         |
++-------------------+----------------------------------------------------------+
+| SETMODE mode      | sets operation mode;                                     |
+|                   +-------------------+--------------------------------------+
+|                   | mode parameter:   | 0 - view mode                        |
+|                   |                   +--------------------------------------+
+|                   |                   | 1 - control mode                     |
++-------------------+-----------------------+----------------------------------+
+| SETMASTERMODE mode| sets clock mode of the devices, used for synchronize     |
+|                   | several devices at the same time                         |
+|                   +-------------------+--------------------------------------+
+|                   | mode parameter:   | 0 - standalone (if only one system is|
+|                   |                   |     used                             |
+|                   |                   | 1 - clock master system (clock is    |
+|                   |                   |     output from this system to the   |
+|                   |                   |     slaves - only one!)              |
+|                   |                   | 2 - clock slave mode (clock will be  |
+|                   |                   |     received from a master system)   |
++-------------------+-------------------+--------------------------------------+
+| SETSAMPLERATE     | sets sampling rate                                       |
+|    samplerate     +---------------------+------------------------------------+
+|                   | samplerate parameter|   sample rate in Hz                |
++-------------------+---------------------+------------------------------------+
+| GETSAMPLERATE     | reads current sample rate                                |
++-------------------+----------------------------------------------------------+
+| LISTUSEDCHS       | lists all used channels                                  |
++-------------------+----------------------------------------------------------+
+| PREPARETRANSFER   | sends a list of channels for live capture. Channels can  |
+|                   | only be selected from used channel syntax:               |
+|                   |                                                          |
+|                   | ::                                                       |
+|                   |                                                          |
+|                   |     /stx preparetransfer                                 |
+|                   |     ch 0                                                 |
+|                   |     .                                                    |
+|                   |     .                                                    |
+|                   |     ch x                                                 |
+|                   |     /etx                                                 |
+|                   |                                                          |
++-------------------+----------------------------------------------------------+
+| STARTTRANSFER     | requests DEWESoft to connect to port 'portno' and feed   |
+|   portno filename | data to client                                           |
+|                   +---------------------+------------------------------------+
+|                   | portno parameter:   | TCP port number on client computer |
++-------------------+---------------------+------------------------------------+
+| STOPTRANSFER      | stops transfer                                           |
++-------------------+----------------------------------------------------------+
+| STARTTRIGTRANSFER | requests DEWESoft to connect to port 'portno' and feed   |
+|     portno        | last trigger data to client                              |
+|                   +---------------------+------------------------------------+
+|                   | portno parameter:   | TCP port number on client computer |
++-------------------+---------------------+------------------------------------+
+| STARTACQ          | start acquisition - measure (more suitable name would be |
+|                   | STARTMEASURE)                                            |
++-------------------+----------------------------------------------------------+
+| STOP              |stop acquisition / leave setup mode and go to start screen|
++-------------------+----------------------------------------------------------+
+| STARTSTORE        | starts storing, also starts acquisition if not yet       |
+|  filename         | started                                                  |
++-------------------+----------------------------------------------------------+
+| SETSTORING status | sets storing on or off on measurement unit               |
+|                   +---------------------+------------------------------------+
+|                   | status parameter:   | ON - remote storing on             |
+|                   +                     +------------------------------------+
+|                   |                     | OFF - remote storing off           |
++-------------------+---------------------+------------------------------------+
+| ENTERSETUP        | enter setup mode / start acquisiton in setup mode        |
++-------------------+----------------------------------------------------------+
+| ISACQUIRING       | returns 'Yes' if acquisition is in progress (measure or  |
+|                   | setup), otherwise 'No'                                   |
++-------------------+----------------------------------------------------------+
+| ISSETUPMODE       | returns 'Yes' if in setup mode, otherwise 'No'           |
++-------------------+----------------------------------------------------------+
+| ISSTORING         |returns 'Yes' if in storing is in progress, otherwise 'No'|
++-------------------+----------------------------------------------------------+
+| ISMEASURING       | returns 'Yes' if acquisition is in progress (measure),   |
+|                   | otherwise 'No'                                           |
++-------------------+----------------------------------------------------------+
+| GETSTATUS         |returns DEWESoft status (measure/analyse mode, clock mode)|
++-------------------+----------------------------------------------------------+
+| SETFULLSCREEN     | sets or clears full screen mode of DEWESoft              |
+|  status           +---------------------+------------------------------------+
+|                   |  status parameter:  | 1 - full screen on                 |
+|                   +                     +------------------------------------+
+|                   |                     | 0 - full screen off                |
++-------------------+---------------------+------------------------------------+
+| SETUP CONNECT     | sets DEWESoft to full screen setup mode.                 |
+|                   | Suitable for VNC remote setup of DEWESoft                |
++-------------------+----------------------------------------------------------+
+| SETUP DISCONNECT  | cancels setup full screen mode                           |
++-------------------+----------------------------------------------------------+
+| DISPLAY START     | sets DEWESoft to full screen display setup mode.         |
+|                   | Suitable for VNC remote setup of DEWESoft displays       |
++-------------------+----------------------------------------------------------+
+| DISPLAY STOP      | cancels display setup mode                               |
++-------------------+----------------------------------------------------------+
+| LOADSETUP filename| loads a setup; filename parameter: setup file stored on  |
+|                   | measurement unit                                         |
++-------------------+----------------------------------------------------------+
+| SAVESETUP filename| saves a setup; filename parameter: setup file to be      |
+|                   | stored on measurement unit                               |
++-------------------+----------------------------------------------------------+
+| NEWSETUP          | clears current DEWESoft setup                            |
++-------------------+----------------------------------------------------------+
+| SETSCREENSIZE     | sets DEWESoft window size in pixels                      |
+|   screensize      +-----------------------+----------------------------------+
+|                   | screensize parameter: | XsizexYSize - sets window size to|
+|                   |                       | Xsize x Ysize (i.e. 640x480)     |
+|                   +-----------------------+----------------------------------+
+|                   |                       | max - maximizes window size      |
++-------------------+-----------------------+----------------------------------+
+
+TODO implement automatic start of DeweSoft instance
+    If the DeweSoft instance isn't already started and no process is running,
+    than automatically start the DeweSoft using an absolute start path.
+"""
+
+
+from io import StringIO
+import logging
+import socket
+
+from datetime import datetime
+
+from .dewenet_data import DeweChannelInfo
+
+
+def dt_now():
+    """Helper method for getting the timestamp
+
+    Will be necessary for testing
+
+    Returns:
+        datetime: current time
+    """
+    return datetime.now()
+
+
+class DeweNetClientException(Exception):
+    """Base exception raised for errors in the DeweNetClient module"""
+
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class DeweNetControllerClient(object):
+    """Client for Communication with DeweSoft.
+
+    The DeweNetControllerClient class implements the necessary functionality
+    for controlling the DeweSoft. Thereby the NET-Plugin for DeweSoft must be
+    registered and the Slave Mode of the DeweSoft program must be activated
+    (Settings-Hardware Setup-NET-Computer role in NETwork -> Slave measurement
+    unit)
+
+    The class uses a TCP-client that connects to an open port of the DeweSoft
+    (usually 8999)
+
+    Example:
+
+    ::
+
+        deweController = DeweNetControllerClient()
+        deweController.connect_to_Dewe('127.0.0.1',8999)
+
+        print "GetSampleRate",deweController.dewe_get_samplerate()
+        print "ISAquiring",deweController.dewe_is_acquiring()
+        print "GetMode",deweController.dewe_get_mode()
+        deweController.dewe_load_setupfile(
+            "C:\\DATA\\Cotevos\\EVTestStand\\EvTestStand.d7s")
+        deweController.dewe_list_used_channels()
+        deweController.dewe_start_acquisition()
+        time.sleep(10)
+        deweController.dewe_stop()
+        deweController.close_Dewe_Connection()
+
+
+    Attributes:
+        EXP_INTF_VERSION (int): Definition of implemented protocol
+            version. If other revisions are used, please check the
+            communication flow for changes.
+
+        _socket (socket): The TCP client socket for communication with the TCP
+            Server of the DeweSoft Slave device
+
+        available_channels (dict): After loading a setup file of the DeweSoft
+            (function dewe_load_setupfile() ) the channels can be read from
+            DeweSoft by using dewe_list_used_channels().
+            This dictionary contains a list of 'DeweChannel' classes with the
+            name of the channel as key. Therefore different settings of the
+            channel are stored (see DeweChannel documentation)
+    """
+
+    EXP_INTF_VERSION = 31
+    """Interface version that is used during development.
+
+    The client is tested against this protocol version.
+    """
+
+    def __init__(self, client_socket=None, logger=None):
+        """Default constructor
+
+        Args:
+            client_socket (socket.socket, optional): Socket for connecting to
+                DeweSoft (usually a TCP socket)
+            logger (logging.logger, optional): Sets the logger
+        """
+        self._logger = logger or logging.getLogger(__name__)
+        self._socket = client_socket or socket.socket(
+            socket.AF_INET, socket.SOCK_STREAM)
+        self.available_channels = dict()
+        self._logger.debug("Initialize DeweNetController Client")
+
+    def connect_to_dewe(self, dewe_ip='127.0.0.1', dewe_port=8999):
+        """Connect to the DeweSoft Net interface
+
+        The function must be called after creation of the
+        DeweNetControllerClient. It will connect to a running instance off
+        DeweSoft on the Host computer and reads the interface version and the
+        version of the DeweSoft.
+
+        Args:
+            dewe_ip (str, optional): IP address of the computer with running
+                DeweSoft
+            dewe_port (int, optional): Open port of the DeweSoft client,
+                usually 8999
+
+        Returns:
+            list: dewe_interface_version, dewe_version
+                dewe_interface_version (int): version of the Dewe-Net interface
+                dewe_version (str): version of the connected DeweSoft instance
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        self._logger.info("Connect to DeweSoft at {}: {}".format(dewe_ip,
+                                                                 dewe_port))
+        dewe_ip = dewe_ip.encode("ascii")
+        self._socket.connect((dewe_ip, dewe_port))
+
+        # get first response after successful connection
+        con_respmsg = self._dewe_read_response()[0]
+        self._logger.debug("Response: '{}'".format(con_respmsg))
+
+        if con_respmsg.startswith("+CONNECTED"):
+            self._logger.info("Connection successfully opened.")
+        else:
+            raise DeweNetClientException(
+                "connect_to_Dewe",
+                "Unkown response received from DeweSoft : " + con_respmsg)
+
+        dewe_interface_version = self._dewe_read_interface_version()
+        dewe_version = self._dewe_read_version()
+        self._logger.info("Interface Version: {}   Version: {}".format(
+            dewe_interface_version, dewe_version))
+        return dewe_interface_version, dewe_version
+
+    def _dewe_read_interface_version(self):
+        """Read the interface version of the connected DeweSoft.
+
+        This helper function reads the interface version of the connected
+        DeweSoft and stores the value in the attribute
+        '_dewe_interface_version'.
+
+        Returns:
+            int: interface version read from DeweSoft
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        response = self._dewe_request_control_message("GETINTFVERSION")[0]
+
+        if response.startswith("+OK"):
+            intf_version = int(response.replace("+OK ", ""))
+
+            if intf_version != DeweNetControllerClient.EXP_INTF_VERSION:
+                self._logger.warn(
+                    "Used Interface with Version '{0}'"
+                    " doesn't match expected one '{1}'.".format(
+                        intf_version,
+                        DeweNetControllerClient.EXP_INTF_VERSION))
+            else:
+                self._logger.debug(
+                    "Used Interface with Version '{0}' matches expected one "
+                    "'{1}'.".format(
+                        intf_version,
+                        DeweNetControllerClient.EXP_INTF_VERSION))
+
+            return intf_version
+
+        else:
+            raise DeweNetClientException(
+                "dewe_read_interface_version",
+                "Error reading interface version: '{}'".format(response))
+
+    def _dewe_read_version(self):
+        """Read the version of the connected DeweSoft
+
+        This helper function reads the version of the connected DeweSoft and
+        stores the value in the attribute '_dewe_version'.
+
+        Returns:
+            str: Version string read from DeweSoft
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        response = self._dewe_request_control_message("GETVERSION")[0]
+
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "dewe_read_version",
+                "Error reading version: '{}'".format(response))
+
+        return response.replace("+OK ", "")
+
+    def disconnect_from_dewe(self):
+        """Closes the connection to the DeweSoft
+
+        """
+        self._logger.info("Close DeweNetControllerClient")
+        self._socket.close()
+
+    def dewe_get_datetime(self):
+        """Read the current time on the measurement device
+
+        Returns:
+            datetime: Current datetime read from DeweSoft
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        response = self._dewe_request_control_message("GETDATETIME")[0]
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "_dewe_get_dateTime: Can't "
+                "convert received message to datetime", response)
+
+        response = response.replace("+OK", "").strip()
+        return datetime.strptime(response, "%d.%m.%Y %H:%M:%S")
+
+    def dewe_set_mode(self, mode=False):
+        """Sets the operation mode of the DeweSoft
+
+        Args:
+            mode (bool,optional): Mode of the DeweSoft
+                False - Set to View Mode
+                True  - Set to Control Mode
+
+        Returns:
+            bool: True - DeweSoft is in control mode
+            False - DeweSoft is in view mode
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        comm_mode = 1 if mode else 0  # generate argument for request
+
+        response = self._dewe_request_control_message(
+            "SETMODE " + str(comm_mode))[0]
+
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+        return mode
+
+    def dewe_get_mode(self):
+        """Read the current mode of the DeweSoft.
+
+        Returns:
+            bool: True - DeweSoft is in control mode
+            False - DeweSoft is in view mode
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        response = self._dewe_request_control_message("GETMODE")[0]
+
+        if response.startswith("+OK"):
+            response = response.split(" ")
+            return int(response[2]) == 1
+
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_start_acquisition(self):
+        """Start the acquisition (measurement) on the DeweSoft
+
+        Returns:
+            time: current time of measurement start
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        if not self.dewe_get_mode():
+            self.dewe_set_mode(True)    # Set to control mode
+
+        response = self._dewe_request_control_message("STARTACQ")[0]
+        if response.startswith("+OK"):
+            return dt_now()
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_start_store(self, filename):
+        """Start the storing function and the acquisition (if not already
+        running) on the DeweSoft
+
+        Args:
+            filename (str): Filename and path of the storage file on local
+                DeweSoft
+
+        Returns:
+            time: current time of measurement start
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+
+        if not self.dewe_get_mode():
+            self.dewe_set_mode(True)    # Set to control mode
+
+        response = self._dewe_request_control_message(
+            "STARTSTORE " + filename)[0]
+        if response.startswith("+OK"):
+            return dt_now()
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error starting storage on DeweSoft: '{}'".format(response))
+
+    def dewe_set_storing(self, storing=True):
+        """Start storing mode of the DeweSoft
+
+        Sets the Mode for the control option of the DEWE connection
+
+        Args:
+            storing (bool): False - Not storing
+                True - Store
+
+        Returns:
+            bool: mode of storing
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        if not self.dewe_get_mode():
+            self.dewe_set_mode(True)    # Set to control mode
+
+        comm_storing = "ON" if storing else "OFF"
+
+        response = self._dewe_request_control_message(
+            "SETSTORING " + comm_storing)[0]
+
+        if response.startswith("+OK"):
+            return storing
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_stop(self):
+        """Stop the acquisition (measurement) and/or storing on the DeweSoft
+
+        Returns:
+            time: current time of measurement start
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        if not self.dewe_get_mode():
+            self.dewe_set_mode(True)    # Set to control mode
+
+        response = self._dewe_request_control_message("STOP")[0]
+        if response.startswith("+OK"):
+            return dt_now()
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_is_acquiring(self):
+        """Get actual state of acquisition
+
+        Returns:
+            bool: True, if DeweSoft is in acquisition mode, otherwise False
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        return self._dewe_get_bool_message("ISACQUIRING")
+
+    def dewe_is_setup_mode(self):
+        """Get actual state of setup mode
+
+        Returns:
+            bool: True, if DeweSoft is in setup mode, otherwise False
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        return self._dewe_get_bool_message("ISSETUPMODE")
+
+    def dewe_is_storing(self):
+        """Get actual state of storing
+
+        Returns:
+            bool: True, if DeweSoft is in storing mode, otherwise False
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        return self._dewe_get_bool_message("ISSTORING")
+
+    def dewe_is_measuring(self):
+        """Get actual state of acquisition
+
+        Returns:
+            bool: True, if DeweSoft is in acquisition mode, otherwise False
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        return self._dewe_get_bool_message("ISMEASURING")
+
+    def dewe_get_status(self):
+        """Get actual status of DeweSOft
+
+        Returns:
+            str: State information of DeweSoft (e.g. Response Mode: Measure,
+                Acquiring; Clock mode: Standalone)
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        response = self._dewe_request_control_message("GETSTATUS")[0]
+        if response.startswith("+OK"):
+            return response.replace("+OK", "").strip()
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_load_setupfile(self, filename):
+        """Loads a setup file stored on the DeweSoft computer
+
+        Args:
+            filename (str): Full Filename with path of the setup file to be
+                loaded
+        Returns:
+            str: Response from DeweSoft
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        if not self.dewe_get_mode():
+            self.dewe_set_mode(True)    # Set to control mode
+
+        response = self._dewe_request_control_message(
+            "LOADSETUP " + filename)[0]
+        if response.startswith("+OK"):
+            return response.replace("+OK", "").strip()
+        else:
+            raise DeweNetClientException(
+                "dewe_set_mode",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+    def dewe_set_samplerate(self, samplefrequency = None):
+        """Writes the sample rate of the DeweS
+        oft
+
+        Returns:
+            int: Sample Rate of DeweSoft in Hz
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        if samplefrequency:
+            response = self._dewe_request_control_message(
+                "SETSAMPLERATE " + str(samplefrequency))[0]
+            #response = self._dewe_request_control_message("GETSAMPLERATE")[0]
+            if response.startswith("+OK"):
+                self._logger.info(response)
+                response = response.replace("+OK", "").strip()
+                self._logger.info(response)
+                response = response[response.find('<') + 1:response.find('>')]
+                self._logger.info(response)
+                return int(response)
+
+            else:
+                self._logger.info(response)
+                raise DeweNetClientException(
+                    "dewe_set_samplerate",
+                    "Can't set samplerate from DeweSoft: '{}'".format(response))
+        else:
+            return None
+
+
+
+    def dewe_get_samplerate(self):
+        """Read the actual sample rate of the DeweSoft
+
+        Returns:
+            int: Sample Rate of DeweSoft in Hz
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        response = self._dewe_request_control_message("GETSAMPLERATE")[0]
+        if response.startswith("+OK"):
+            return int(response.replace("+OK", "").strip())
+        else:
+            raise DeweNetClientException(
+                "dewe_get_samplerate",
+                "Can't read samplerate from DeweSoft: '{}'".format(response))
+
+    def dewe_list_used_channels(self):
+        """Read all available channels from DeweSoft with its parameters
+
+        This function reads all available channels from the DeweSoft and stores
+        it in the available_channels list. Then it is possible to get these
+        values for further work. (using client.available_channels.keys())
+        """
+        response = self._dewe_request_control_message("LISTUSEDCHS")
+
+        for line in response:
+            element = line.split("\t")
+
+            if len(element) > 22:
+               channel = DeweChannelInfo(channel_number=element[2],
+                                          name=element[3],
+                                          unit=element[5],
+                                          samplerate_divider=element[6],
+                                          measurement_type=element[8],
+                                          sample_data_type=element[9],
+                                          buffer_size=element[10],
+                                          custom_scale=element[11],
+                                          custom_offset=element[12],
+                                          scale_raw_data=element[13],
+                                          offset_raw_data=element[14],
+                                          description=element[15],
+                                          settings=element[16] + " " + element[19],
+                                          range_min=element[17],
+                                          range_max=element[18],
+                                          value_min=element[21],
+                                          value_max=element[22],
+                                          value_act=(element[23]
+                                                     if len(element) > 23 else 0.0))
+               self.available_channels[channel.name] = channel
+            elif len(element) > 18:
+
+                channel = DeweChannelInfo(channel_number=element[2],
+                                      name=element[3],
+                                      unit=element[5],
+                                      samplerate_divider=element[6],
+                                      measurement_type=element[8],
+                                      sample_data_type=element[9],
+                                      buffer_size=element[10],
+                                      custom_scale=element[11],
+                                      custom_offset=element[12],
+                                      scale_raw_data=element[13],
+                                      offset_raw_data=element[14],
+                                      description=element[15],
+                                      settings=element[16] + " " + element[19],
+                                      range_min=element[17],
+                                      range_max=element[18],
+                                      value_min=0.0,
+                                      value_max=0.0,
+                                      value_act=0.0)
+                self.available_channels[channel.name] = channel
+            else:
+                raise DeweNetClientException(
+                    "Error reading channel",
+                    "Channel {} hasn't enough elements".format(
+                        element[3] if len(element) > 3 else "unknown"))
+
+    def dewe_read_last_values(self):
+        """Read last values from DeweSoft
+
+        This method uses the client interface to read current values from
+        DeweSoft.
+        This method can be used as a fallback solution to read values cyclic.
+
+        Returns:
+            list: List of tuples containing all DeweSoft channels
+                tuple: (ch_number,ch_name,value)
+                    ch_number (int): number of DeweSoft channel
+                    ch_name (str): Name of the channel
+                    value (float): Last value of the channel
+        """
+        response = self._dewe_request_control_message("LISTUSEDCHS")
+        channels = list()
+        for line in response:
+            element = line.split("\t")
+            if len(element) > 23:
+                channel = (int(element[2]), element[3], float(element[23]))
+                channels.append(channel)
+                del channel
+        return channels
+
+    def dewe_prepare_transfer(self, channel_list):
+        """Transmit a list of channels, which you want to be automatically
+        transmitted by DeweSoft.
+
+        This function must be called before the `dewe_start_transfer()` is
+        called to rightly configure the DeweSoft communication.
+
+        Args:
+            channel_list (list): List of channels names (order will be taken
+                into account by transfering data values)This argument must be
+                a list of string containing the names of the channels
+
+                Example:
+                    [r'Power_AC_Netz/U_rms_L1',r'Power_AC_Netz/U_rms_L2',
+                        r'Power_AC_Netz/U_rms_L3']
+        Raises:
+            DeweNetClientException: If the channels can't be prepared
+        """
+        request = "/stx PREPARETRANSFER\r\n"
+        for channel in channel_list:
+            request += "ch {}\r\n".format(self.available_channels[
+                channel].channel_number)
+        request += "/etx\r\n"
+
+        response = self._dewe_request_control_message(request)[0]
+
+        if not response.startswith("+OK"):
+            self._logger.debug(response)
+            raise DeweNetClientException(
+                "dewe_prepare_transfer",
+                "Can't prepare channels for transfer: '{}'".format(response))
+
+    def dewe_start_transfer(self, port_number):
+        """Start the transfer of values from DeweSoft to the
+        DeweNetControllerServer
+
+        Args:
+            port_number (int): Port number of the client, which will be used
+                from the `DeweNetControllerServer`
+        Raises:
+            DeweNetClientException: If the transfer can't be started
+        """
+        response = self._dewe_request_control_message(
+            "STARTTRANSFER {}".format(port_number))[0]
+
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "dewe_start_transfer",
+                "Error setting mode of DeweSoft: '{}'".format(response))
+
+    def dewe_init_start_transfer(self, port_number, channel_list):
+        """Combination of the prepare_transfer and the start transfer command
+
+        Args:
+            port_number (int): Port number of the client, which will be used
+                from the `DeweNetControllerServer`
+            channel_list (list): List of channels names (order will be taken
+                into account by transfering data values)This argument must be
+                a list of string containing the names of the channels
+        Raises:
+            DeweNetClientException: If the transfer can't be started
+        """
+        self.dewe_prepare_transfer(channel_list)
+        self.dewe_start_transfer(port_number)
+
+    def dewe_start_trigger_transfer(self, port_number):
+        """Start the data transfer and get the already last stored values from
+        DeweSoft
+
+        Args:
+            port_number (int): Port number of the client, which will be used
+                from the `DeweNetControllerServer`
+
+        Raises:
+            DeweNetClientException: If the transfer can't be started
+        """
+        response = self._dewe_request_control_message(
+            "STARTTRIGTRANSFER " + str(port_number))[0]
+
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "dewe_start_trigger_transfer",
+                "Can't start trigger transfer: '{}'".format(response))
+
+    def dewe_stop_transfer(self):
+        """Stops an actual running transmission from DeweSoft
+
+        Raises:
+            DeweNetClientException: If the transfer can't be stopped
+        """
+        response = self._dewe_request_control_message("STOPTRANSFER")[0]
+
+        if not response.startswith("+OK"):
+            raise DeweNetClientException(
+                "dewe_stop_transfer",
+                "Error stopping transfer of DeweSoft: '{}'".format(response))
+
+    def _dewe_request_control_message(self, request):
+        """Sends a request to the Dewesoft and waits for a response.
+
+        Args:
+            request (str): Request string of the command for DeweSoft
+                communication.
+        Returns:
+            str: Response message
+
+        Raises:
+            DeweNetClientException: If an error is occured during communication.
+        """
+        if not request.endswith("\r\n"):
+            request = request + "\r\n"
+
+        self._socket.sendall(request.encode())
+        self._logger.debug("Request: '" + request.replace("\r\n", "") + "'")
+
+        response = self._dewe_read_response()
+
+        if not response:
+            raise DeweNetClientException("dewe_request_control_message",
+                                         "No response received from DeweSoft.")
+
+        self._logger.debug("Response: '{}'".format(response))
+        return response
+
+    def _dewe_read_response(self):
+        """Read the Response of the DeweSoft message
+
+        This function receives a single line response or a multiline response
+        from DeweSoft
+
+        Returns:
+            str: Response message striped by end delimiter
+        """
+        response = self._readlines()
+
+        if response[0].startswith("+STX"):
+            while True:
+                if response[-1].startswith("+ETX"):
+                    return response[1:-1]
+                response.extend(self._readlines())
+        else:  # single line response
+            return response
+
+    def _readlines(self, delimiter="\r\n"):
+        """Read lines from socket.
+
+        Args:
+            delimiter (str): Delimiter of a line
+
+        Returns:
+            list: A list of lines with removed line delimiter
+        """
+        eol = delimiter[-1:].encode()  # last character
+
+        buff = StringIO()
+        while True:
+            data = self._socket.recv(1024)
+            buff.write(data.decode())
+            if data.endswith(eol):
+                break
+
+        return_lines = buff.getvalue().splitlines()
+        return [string.strip() for string in return_lines]
+
+    def _dewe_get_bool_message(self, request):
+        """Read a bool value from DeweSoft.
+
+        Args:
+            request (str): Request that is sent.
+
+        Returns:
+            bool: Response as bool value
+
+        Raises:
+            DeweNetClientException: if an error during request occurs.
+        """
+        response = self._dewe_request_control_message(request)[0]
+        response = str(response)
+
+        if isinstance(response, str) and response.startswith("+OK"):
+            response = response.split(" ")
+            return response[1].upper() == "YES"
+        else:
+            raise DeweNetClientException(
+                'get_bool_message',
+                "Error reading bool value from DeweSoft: '{}'".format(response))

--- a/Lib/svpelab/dewenetcontroller/dewenet_data.py
+++ b/Lib/svpelab/dewenetcontroller/dewenet_data.py
@@ -1,0 +1,558 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+
+
+
+
+
+
+
+
+
+
+
+
+
+""" Storage Classes for a DeweSoft Channel
+
+This module contains the classes which are used for storage and organisation of
+Dewe Soft channel, which are read by the Net interface.
+
+
+Channel information (From DeweSoft Net Interface Manual)
+==============================================================
+
+Binary data delivered to client are always raw binary data. To get information
+about sample data type, scaling and other important info of every channel client
+should send 'LISTUSEDCHS' command. Response contains following info for each
+channel separated by tab character
+
++-------------+-----------------------------------------+---------------------+
+| Data        |     Description                         |     Data type       |
++=============+=========================================+=====================+
+| CH          | Fixed string                            |                     |
++-------------+-----------------------------------------+---------------------+
+| Number      | Consequent channel number               | Integer number      |
++-------------+-----------------------------------------+---------------------+
+| Name        | Channel name                            | Text                |
++-------------+-----------------------------------------+---------------------+
+| Unit        | Measure unit                            | Text                |
++-------------+-----------------------------------------+---------------------+
+| Samplerate  | Divider for sync channel                | Integer number or   |
+| divider     +-----------------------------------------+ text                |
+|             | 'Async' for async channels,             |                     |
+|             +-----------------------------------------+                     |
+|             | 'SingleValue' for single value channels |                     |
++-------------+-----------------------------------------+---------------------+
+| Measurement | Defines channel meaning                 | Integer number      |
+| type        |                                         |                     |
++-------------+-----------------------------------------+---------------------+
+| Sample data | 0 - 8 bit unsigned integer              |                     |
+| type        +-----------------------------------------+                     |
+|             | 1 - 8 bit signed integer                |                     |
+|             +-----------------------------------------+                     |
+|             | 2 - 16 bit signed integer               |                     |
+|             +-----------------------------------------+                     |
+|             | 3 - 16 bit unsigned integer             |                     |
+|             +-----------------------------------------+                     |
+|             | 4 - 32 bit signed integer               |                     |
+|             +-----------------------------------------+                     |
+|             | 5 - Single floating point (32bit)       |                     |
+|             +-----------------------------------------+                     |
+|             | 6 - 64 bit signed integer               |                     |
+|             +-----------------------------------------+                     |
+|             | 7 - Double floating point (64 bit)      |                     |
++-------------+-----------------------------------------+---------------------+
+| Buffer size | Buffer size for data                    | Integer number      |
++-------------+-----------------------------------------+---------------------+
+| Custom scale| Custom scale after amplifier            | Float number        |
++-------------+-----------------------------------------+---------------------+
+|Custom offset| Custom offset after amplifier           | Float number        |
++-------------+-----------------------------------------+---------------------+
+| Scale raw   | Scale for raw data                      | Float number        |
+| data        |                                         |                     |
++-------------+-----------------------------------------+---------------------+
+| Offset raw  | Offset for raw data                     | Float number        |
+| data        |                                         |                     |
++-------------+-----------------------------------------+---------------------+
+| Description | Channel description                     | Text                |
++-------------+-----------------------------------------+---------------------+
+| Settings    | Channel settings                        | Text                |
++-------------+-----------------------------------------+---------------------+
+| Range min   | Range min in scaled units               | Float number        |
++-------------+-----------------------------------------+---------------------+
+| Range max   | Range max in scaled units               | Float number        |
++-------------+-----------------------------------------+---------------------+
+| Actual Value| Actual value in scaled unit             | Float number        |
++-------------+-----------------------------------------+---------------------+
+
+
+To get real scaled value, client has to apply the following formula:
+ScaledValue = ScaleRawData * RawValue + OffsetRawData
+
+
+.. warning:: The received values from `list_used_chs` can be differ in the
+   length of the given protocol.
+
+Channels in data packet are delivered in the same order they are included in
+'PREPARE TRANSFER' command.
+
+Binary data format, which will be receied by the server
+
+Header
+----------------------------------------------------
+
++-------+-------+---------------+---------------------------------------------+
+|Offset |Length |Data type      |   Description                               |
+|(bytes)|(bytes)|               |   Comment                                   |
++=======+=======+===============+=============================================+
+|  0    |  8    |               |Start packet string                          |
+|       |       |               | 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07     |
++-------+-------+---------------+---------------------------------------------+
+|  8    |  4    |Integer 32 bit |Packet size                                  |
+|       |       |               |Size in bytes without stop and start string  |
++-------+-------+---------------+---------------------------------------------+
+| 12    |  4    |Integer 32 bit |Packet type                                  |
+|       |       |               |Always 0 for data packets                    |
++-------+-------+---------------+---------------------------------------------+
+| 16    |  4    |Integer 32 bit |Samples in packet                            |
+|       |       |               |Number of synchronous samples per ch.        |
++-------+-------+---------------+---------------------------------------------+
+| 20    |  8    |Integer 64 bit |Samples acquired so far                      |
++-------+-------+---------------+---------------------------------------------+
+| 28    |  8    |Double floating|Absolute/relative time                       |
+|       |       |point          |Number of days since 12/30/1899              |
+|       |       |               |Number of days since start of acq.           |
++-------+-------+---------------+---------------------------------------------+
+
+Off = 36 bytes,
+
+
+Repeat for each channel
+------------------------------------------------------
+
+* If Channel is asynchronous
++--------------+--------------+----------------+------------------------------+
+| Offset       | Length       | Data type      |    Description               |
+| (bytes)      | (bytes)      |                |    Comment                   |
++==============+==============+================+==============================+
+| Off          | 4            | 4              | Number of samples            |
+|              |              |                | = X                          |
++--------------+--------------+----------------+------------------------------+
+| Off + 4      |X * SampleSize|Sample data type| Data samples                 |
++--------------+--------------+----------------+------------------------------+
+| Off + 4 +    | X * 8        | Integer 64 bit | Timestamp samples            |
+|X * SampleSize|              |                | Timestamps for samples       |
+|              |              |                | since start of acquisition   |
++--------------+--------------+----------------+------------------------------+
+Off = Off + 4 + X * (SampleSize + 8)
+
+
+* If Channel is synchronous
++--------------+---------------+----------------+-----------------------------+
+| Offset       | Length        | Data type      |    Description              |
+| (bytes)      | (bytes)       |                |    Comment                  |
++==============+===============+================+=============================+
+| Off          | 4             | 4              | Number of samples           |
+|              |               |                | = X = SamplesInPacket div   |
+|              |               |                | Channel SR divider          |
++--------------+---------------+----------------+-----------------------------+
+| Off + 4      |X * SampleSize |Sample data type| Data samples                |
++--------------+---------------+----------------+-----------------------------+
+Off = Off + 4 + X * SampleSize
+
+
+* If Channel is single value
++--------------+--------------+-----------------+-----------------------------+
+| Offset       | Length       | Data type       |    Description              |
+| (bytes)      | (bytes)      |                 |    Comment                  |
++==============+==============+=================+=============================+
+| Off          | 4            | 4               | Number of samples           |
+|              |              |                 | Always 1                    |
++--------------+--------------+-----------------+-----------------------------+
+| Off + 4      | 8            | Double floating | Data sample                 |
+|              |              | point           |                             |
++--------------+--------------+-----------------+-----------------------------+
+Off = Off + 12
+
+
+End repeat
+--------------------------------------------------------
++--------------+--------------+-----------------+-----------------------------+
+| Offset       | Length       | Data type       |    Description              |
+| (bytes)      | (bytes)      |                 |    Comment                  |
++==============+==============+=================+=============================+
+| Off          | 8            |                 | Stop packet string          |
+|              |              |                 | 0x07 0x06 0x05 0x04 0x03    |
+|              |              |                 | 0x02 0x01 0x00              |
++--------------+--------------+-----------------+-----------------------------+
+
+"""
+
+import threading
+
+
+def _local_handler(name, value, timestamp):
+    """A local handler implementation as backup solution.
+
+    This method will be used if no update handler will be set.
+
+    Args:
+        name (str): Name of the channel
+        value (float): Value of hte measured sample
+        timestamp (float): Relative timestamp of the value in seconds since
+            start of acquisition
+    """
+    pass
+
+
+class DeweChannel:
+    """ Representation of a DeweSoft channel.
+
+    This class is used for storage and representation of a DeweSoft channel.
+
+    Attributes:
+        channel_info (DeweChannelInfo): Channel information read from DeweSoft
+        last_value (float): Last received raw value of the channel
+        last_timestamp (float): Last received relative timestamp of the channel
+        update_handler (function): Reference to the handler function
+
+        _values_lock (RLock):
+
+    """
+
+    def __init__(self, channel_info, update_handler=None):
+        """ Constructor.
+
+        Args:
+            channel_info (DeweChannelInfo): Static information about the
+                DeweSoft channel_info
+
+            update_handler (function): Reference to update handler function.
+
+                The function must have three arguments:
+                    name (str): Name of the channel
+                    index (int): last index from DeweSoft of the received value.
+                        Can be used to calculate the timestamp of the value
+                        using the timestamp of the measurement start.
+                    value (float): scaled value of the last received point
+
+                    Example of the handler function:
+                        def update_value(name, index, value):
+                            print("Update Handler called:",name, index, value)
+        """
+        self.channel_info = channel_info
+        self.last_value = None
+        self.last_timestamp = None
+
+        self._values_lock = threading.RLock()
+        self.update_handler = update_handler or _local_handler
+
+    def __str__(self, *args, **kwargs):
+
+        ret_str = "Channel {}: ".format(self.channel_info.name)
+
+        if self.last_value:
+            ret_str += "{} {} at index {}".format(self.last_value,
+                                                  self.channel_info.unit,
+                                                  self.last_timestamp)
+        else:
+            ret_str += "No value available"
+        return ret_str
+
+    def __repr__(self, *args, **kwargs):
+        return "{} (Channel)".format(self.channel_info.name)
+
+    def get_info_as_dict(self):
+        """Get all references as dict
+
+        Get all stored information variables of the channel as an dictionary
+
+        Returns:
+            dict: Dict of all stored attributes for easier handling
+
+        """
+        last_timestamp, last_value = self.get_last_value()
+        info = {
+            'last_value': last_value,
+            'last_timestamp': last_timestamp
+        }
+        info.update(self.channel_info.get_info_as_dict())
+        return info
+
+    def set_value(self, raw_value, timestamp):
+        """Set a new value
+
+        Sets a new value (threadsafe) of the channel with its index. After that
+        it will call all stored update handler by the new value
+
+        Args:
+            raw_value (float): value of the data point (type is listed in
+                channel info)
+            timestamp (float): index of the data point
+        """
+
+        with self._values_lock:
+            self.last_timestamp = timestamp
+            self.last_value = raw_value
+
+        if self.update_handler:
+            last_value = self._calc_value_raw(raw_value)
+            self.update_handler(self.channel_info.name, last_value, timestamp)
+
+    def get_last_value(self):
+        """ Read the last value of the channel
+
+        This function reads (threadsafe) the last stored value of the channel
+
+        Returns:
+            list: output list containing two elements
+                 float: calculated value of the last receive measurement value
+                 float: timestamp in seconds since start of acquisition
+        """
+        with self._values_lock:
+            if self.last_value is None:
+                raise ValueError('No value available for {0}'.format(self.channel_info.name))
+        
+            return self._calc_value_raw(self.last_value), self.last_timestamp
+
+    def _calc_value_raw(self, raw_value):
+        """ Calculate the scaled value of the channel
+
+        Returns calculates (scaled) value of the Channel given by its position
+
+        Args:
+            raw_value (number): raw value that should be converted.
+
+        Returns:
+            Float: calculated scaled value of the channel's raw value
+
+        """
+        
+        calcvalue = raw_value * self.channel_info.scale_raw_data * \
+            self.channel_info.custom_scale + \
+            self.channel_info.offset_raw_data + self.channel_info.custom_offset
+        return calcvalue
+
+
+class DeweChannelInfo:
+    ''' Information header of a channel of DeweSoft
+
+    This class contains the header information of a DeweSoft channel.
+    These values are transmitted by the DeweSoft using the 'listusedchs'
+    command. Fur detailed information see DeweSoft Net interface manual
+
+    Attributes:
+        see module description
+
+        channel_number (int):
+        name (str):
+        unit (str):
+        samplerate_divider (int,str)
+        measurement_type (int):
+        sample_data_type (int):
+        buffer_size (int):
+        custom_scale (float):
+        custom_offset (flaot):
+        scale_raw_data (float):
+        offset_raw_data (float):
+        settings (str):
+        range_min (float):
+        range_max (float):
+        value_min (float):
+        value_max (float):
+        value_act (float):
+    '''
+
+    def __init__(self, channel_number, name, unit, samplerate_divider,
+                 measurement_type, sample_data_type, buffer_size,
+                 custom_scale, custom_offset, scale_raw_data, offset_raw_data,
+                 description, settings, range_min, range_max, value_min,
+                 value_max, value_act):
+        ''' Constructor
+
+        Args:
+            Information, which are transmitted by the DeweSoft 'listusedchs'
+            command
+        '''
+        self.channel_number = int(channel_number)   # int
+        self.name = str(name)  # string
+        self.unit = str(unit) if unit != "-" else ""  # string
+        if samplerate_divider.isdigit():
+            self.samplerate_divider = int(samplerate_divider)    # int,string
+        else:
+            self.samplerate_divider = str(samplerate_divider).upper()
+
+        self.measurement_type = int(measurement_type)  # int
+        self.sample_data_type = int(sample_data_type)  # int
+        self.buffer_size = int(buffer_size)   # int
+        self.custom_scale = DeweChannelInfo.convert_str_to_float(custom_scale)
+        self.custom_offset = DeweChannelInfo.convert_str_to_float(
+            custom_offset)
+        self.scale_raw_data = DeweChannelInfo.convert_str_to_float(
+            scale_raw_data)
+        self.offset_raw_data = DeweChannelInfo.convert_str_to_float(
+            offset_raw_data)
+        self.description = str(description)
+        self.settings = str(settings)
+        self.range_min = DeweChannelInfo.convert_str_to_float(range_min)
+        self.range_max = DeweChannelInfo.convert_str_to_float(range_max)
+        self.value_min = DeweChannelInfo.convert_str_to_float(value_min)
+        self.value_max = DeweChannelInfo.convert_str_to_float(value_max)
+        self.value_act = DeweChannelInfo.convert_str_to_float(value_act)
+
+    @property
+    def type(self):
+        """Get the type of the channel as str.
+
+        Returns:
+            str: "sync" for a synchronous channel,
+                 "async" for an asynchronous channel,
+                 "single" for a single ValueError
+        """
+        if isinstance(self.samplerate_divider, int):
+            return "sync"
+        elif (isinstance(self.samplerate_divider, str) and
+              self.samplerate_divider == "ASYNC"):
+            return "async"
+        elif (isinstance(self.samplerate_divider, str) and
+              self.samplerate_divider == "SINGLEVALUE"):
+            return "single"
+
+    @staticmethod
+    def convert_str_to_float(string_value):
+        """Convert a string value into a float.
+
+        The method will also accept float values that are divided by a colon.
+
+        Args:
+            string_value (str): String containing float value to be converted.
+
+        Returns:
+            float: converted value from string
+        """
+
+        if isinstance(string_value, str):
+            string_value = string_value.replace(",", ".")
+        return float(string_value)  # float
+
+    def __str__(self, *args, **kwargs):
+        string = "DeweCh {} ({}): \r\n".format(self.channel_number, self.name)
+        string += "\tUnit: {}\r\n".format(self.unit)
+        string += "\tSamplerate Divider: {}\r\n".format(
+            self.samplerate_divider)
+        string += "\tMeasurement Type: {}\r\n".format(self.measurement_type)
+        string += "\tSample Data Type: {}\r\n".format(self.sample_data_type)
+        string += "\tBuffer Size: {}\r\n".format(self.buffer_size)
+        string += "\tCustom Scale: {}\r\n".format(self.custom_scale)
+        string += "\tCustom Offset: {}\r\n".format(self.custom_offset)
+        string += "\tScale Raw Data: {}\r\n".format(self.scale_raw_data)
+        string += "\tOffset Raw Data: {}\r\n".format(self.offset_raw_data)
+        string += "\tDescription: {}\r\n".format(self.description)
+        string += "\tSettings: {}\r\n".format(self.settings)
+        string += "\tRange min: {}\r\n".format(self.range_min)
+        string += "\tRange max: {}\r\n".format(self.range_max)
+        string += "\tValue min: {}\r\n".format(self.value_min)
+        string += "\tValue max: {}\r\n".format(self.value_max)
+        string += "\tActual Value: {}\r\n".format(self.value_act)
+        return string
+
+    def __repr__(self, *args, **kwargs):
+        return self.name + " (ChannelInfo)"
+
+    def get_info_as_dict(self):
+        """ Get all references as dict.
+
+        Get all stored information variables of the channel as an dictionary.
+
+        Returns:
+            dict: Dict of all stored attributes
+        """
+        info = {
+            'name': self.name,
+            'unit': self.unit,
+            'samplerate_divider': self.samplerate_divider,
+            'measurement_type': self.measurement_type,
+            'sample_data_type': self.sample_data_type,
+            'buffer_size': self.buffer_size,
+            'custom_scale': self.custom_scale,
+            'custom_offset': self.custom_offset,
+            'scale_raw_data': self.scale_raw_data,
+            'offset_raw_data': self.offset_raw_data,
+            'value_act': self.value_act,
+            'settings': self.settings,
+            'channel_number': self.channel_number,
+            'range_min': self.range_min,
+            'range_max': self.range_max,
+            'value_min': self.value_min,
+            'value_max': self.value_max
+        }
+
+        return info
+
+    _value_converter = {
+        'size': {0: 1, 1: 1, 2: 2, 3: 3, 4: 4, 5: 4, 6: 8, 7: 8},
+        'decoder': {0: 'B', 1: 'b', 2: 'h', 3: 'H',
+                    4: 'i', 5: 'f', 6: 'q', 7: 'd'}
+    }
+
+    # Converter dictionary for DeweSoft's data types.
+
+    # The converter dictionary will contains following entries:
+
+    # size: The number of bytes that are used to store the specific DeweSoft's
+    #       data value. It will be used by the TCP server to receive the
+    #       specific number of byter
+    # decoder: The formatter string for the struct.unpack function to interpret
+    #          the received bytes during the encoding of the raw values.
+
+    def get_value_size(self):
+        """ Read size of value.
+
+        This function calculates the used size of the channel's value in bytes.
+
+        Returns:
+            int: Size of the value calculated in number of bytes
+        """
+        return DeweChannelInfo._value_converter['size'][self.sample_data_type]
+
+    def get_value_format(self):
+        """ Get the value formatter.
+
+        Get the formatter for the struct command of the stored channel
+
+        Returns:
+            str: formatter string for using in the struct conversion
+
+        """
+        decoder = DeweChannelInfo._value_converter['decoder']
+        return decoder[self.sample_data_type]

--- a/Lib/svpelab/dewenetcontroller/dewenet_server.py
+++ b/Lib/svpelab/dewenetcontroller/dewenet_server.py
@@ -1,0 +1,391 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+
+
+
+
+
+
+""" Server for the DeweNetController
+
+This module contains the server, which is necessary for real time communication
+with the DeweSoft Net interface.
+
+The DeweSoft will send its measured values to this server.
+"""
+
+import socket
+import struct
+import codecs
+
+import threading
+import logging
+
+
+class DeweNetControllerServer(threading.Thread):
+    """TCP Server for communication with the DeweSoft Net interface.
+
+    The server will receive actual measurement values from the DeweSoft unit.
+    Therefore a real time communication with actual data transport can be built
+    up.
+
+    Usage: The server must be initialized by the controller. Therefore it needs
+    a list of channels (order is related), which is transmitted to the DeweSoft
+    system by the DeweNetControllerClient before.
+
+    The DeweSoft sends packets with actual measurement data to the opened
+    server: The list_of_channel and its order is required to translate the
+    received packet to the actual data.
+
+    Attributes:
+        START_OF_MESSAGE (bytes): Start bytes of packet
+        END_OF_MESSAGE (bytes): End bytes of packet
+
+        _logger (logging.logger): Logger of the class
+        _server_ip (str): IP address of the server
+        _tcp_port (int): TCP port of the server
+        _socket: server socket of the server
+        _list_of_channels (list): List of DeweChannel
+        _keep_running (bool): running flag for the server thread
+        read_only_single_values: read only the last value of the incoming
+            packet.
+        samplerate (int): Samplerate of the current measurement
+        _last_chunk (bytes): last received chunk. This state variable will be
+            used to temporarily store the last half received message.
+    """
+
+    START_OF_MESSAGE = codecs.decode('0001020304050607', 'hex_codec')
+    END_OF_MESSAGE = codecs.decode('0706050403020100', 'hex_codec')
+
+    def __init__(self, list_of_channels, server_ip="",
+                 tcp_port=9000, read_only_single_values=True,
+                 server_socket=None, logger=None):
+        """ Constructor
+
+        Args:
+            list_of_channels (list): list of strings containing the list of
+                channels that will be received from DeweSoft. This list is set
+                during the client's prepareTransfer.
+            server_ip (str): IP address of the TCP server Default: ""
+            tcp_port (int): TCP port of the server Default: 9000
+            read_only_single_values (bool): read only last value for
+                each channel of the incoming data packet.
+            server_socket (socket.socket): Socket for the TCP server
+            logger (logging.logger): Logger of the class
+
+        """
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self._logger = logger or logging.getLogger(__name__)
+
+        self._tcp_port = tcp_port
+        self._server_ip = server_ip
+        self._socket = server_socket or socket.socket(socket.AF_INET,
+                                                      socket.SOCK_STREAM)
+
+        self._list_of_channels = list(list_of_channels)
+        self._keep_running = True
+
+        self.read_only_single_values = read_only_single_values
+        self.samplerate = 1
+
+        self._last_chunk = b''
+
+    def run(self):
+        """ Run method of the server thread
+
+        It will opened the server socket at the given port and it will
+        wait for incoming packet.
+        """
+        threading.Thread.run(self)
+        self._logger.debug("Start run IP: {}, Port {}".format(self._server_ip,
+                                                              self._tcp_port))
+        self._socket.bind((self._server_ip, self._tcp_port))
+        self._socket.listen(1)
+
+        connection, client = self._socket.accept()
+        self._socket.settimeout(5.0)
+        self._logger.info("Client connected: " + str(client))
+
+        while self._keep_running:
+            try:
+                self._handle_message(connection)
+            except (KeyboardInterrupt, RuntimeError) as ex:
+                self._logger.warn("Stopping server.", ex)
+                self._keep_running = False
+
+    def close_server(self):
+        """ Close the server thread
+        """
+        self._logger.info("Close DeweNetControllerServer")
+        self._keep_running = False
+
+    def _handle_message(self, connection):
+        """ Message parser for incoming packets
+
+        This helper function will parse the incoming message block and convert
+        the measurement data to the dedicated channel storage.
+
+        See DeweSoft-NET manual (or DeweChannel module description) for further
+        description of the incoming packet
+
+        Args:
+            connection: connection that is used to receive data from the socket.
+        """
+        messages = self._read_messages(connection)
+
+        if self.read_only_single_values:
+            messages = messages[-1:]
+
+        for message in messages:
+            self._parse_message(message)
+
+    def _read_messages(self, connection):
+        """Read messages from the socket.
+
+        Args:
+            connection: connection that is used to receive data from the socket.
+
+        Returns:
+            list: List of messages that are received. The messages are stored
+                as bytes.
+        """
+        self._logger.debug("Wait for data")
+
+        chunk = [self._last_chunk]
+
+        while True:
+            data = connection.recv(4096)
+            chunk.append(data)
+            if data.find(DeweNetControllerServer.END_OF_MESSAGE) != -1:
+                break
+
+        chunk = b''.join(chunk)
+
+        messages, self._last_chunk = _split_messages(
+            chunk,
+            DeweNetControllerServer.START_OF_MESSAGE,
+            DeweNetControllerServer.END_OF_MESSAGE)
+
+        return messages
+
+    def _parse_message(self, chunk):
+        """Parse a received message.
+
+        Args:
+            chunk (bytes): received data that represents the message in bytes.
+        """
+
+        try:
+            chunk, header = Header.from_bytes(chunk)
+            chunk = self._read_channels(header, chunk)
+            # log message
+            if self._logger.isEnabledFor(logging.DEBUG):
+                outstr = "Received Packet: "
+                outstr += header.log_format()
+                self._logger.debug(outstr)
+
+        except struct.error as ex:
+            self._logger.warn("Error during parsing message", ex)
+            return
+
+    def _read_channels(self, header, chunk):
+        """Read channel informations from packet
+
+        Args:
+            header (Header): Parsed header of the received message.
+            chunk (bytes): the packet bytes
+        Returns:
+            bytes: reduced chunk with removed channel bytes
+        """
+        # parse and handle channels in the received packet
+        for channel in self._list_of_channels:
+            chinfo = channel.channel_info
+            # get data format and data size from the channel info
+            value_size_byte = chinfo.get_value_size()
+            value_formatter = chinfo.get_value_format()
+
+            # read samples counter for the next channel
+            chunk, samples_nr = _read_number_of_samples(chunk)
+
+            # Read only the last values of the received packet
+            # or read all values of the packet
+            if samples_nr > 0 and self.read_only_single_values:
+                range_begin = samples_nr - 1
+            else:
+                range_begin = 0
+
+            # Read list of values
+            for i in range(range_begin, samples_nr):
+
+                begin_chunk_index = i * value_size_byte
+                end_chunk_index = begin_chunk_index + value_size_byte
+                sample_value = struct.unpack_from(
+                    "<" + value_formatter,
+                    memoryview(chunk[begin_chunk_index:end_chunk_index]))[0]
+
+                # read timestamp
+                if chinfo.type == "sync":
+                    timestamp_sample_index = header.samples_acquired_so_far + \
+                        (i * chinfo.samplerate_divider)
+
+                    timestamp_sample = \
+                        float(timestamp_sample_index) / float(self.samplerate)
+
+                elif chinfo.type == "async":
+                    delta_index_time_value = samples_nr * value_size_byte
+                    begin_time_index = i * 8 + delta_index_time_value
+                    end_time_index = begin_time_index + 8
+
+                    timestamp_sample = struct.unpack_from(
+                        "<d",
+                        memoryview(chunk[begin_time_index:end_time_index]))[0]
+
+                else:  # also if chinfo.type == "single":
+                    timestamp_sample = header.time_of_packet_in_sec
+
+                # Set the value
+                channel.set_value(sample_value, timestamp_sample)
+
+            # Remove from chunk
+            begin_next = samples_nr * value_size_byte
+            if chinfo.type == "async":
+                begin_next += samples_nr * 8
+            chunk = chunk[begin_next:]
+
+        return chunk
+
+
+def _split_messages(chunk, som, eom):
+    """Split messages from the chunk.
+
+    Args:
+        chunk (bytes): Received data containing multiple messages.
+        som (bytes): Start bytes of message
+        eom (bytes): End bytes of message
+
+    Returns:
+        list: containing two elements
+            list: list of splitted messages in bytes.
+            bytes: end part containing half received message. This part can
+                be used during the next receiving of data.
+    """
+    end_part = b''
+    first_som = chunk.find(som)
+    if first_som == -1:
+        return [], end_part
+    elif first_som > 0:
+        chunk = chunk[first_som:]
+
+    last_eom = chunk.rfind(eom)
+    if last_eom == -1:
+        return [], [chunk]
+    elif last_eom <= len(chunk) - len(eom):
+        end_part = chunk[last_eom+len(eom):]
+        chunk = chunk[:last_eom+len(eom)]
+    else:
+        raise Exception("Split Messages: Len of chunk is too low")
+
+    messages = chunk.split(som)
+    messages = [msg[:msg.rfind(eom)] for msg in messages if msg]
+
+    return messages, end_part
+
+def _read_number_of_samples(chunk):
+    """Read the number from samples of a channel
+    Args:
+        chunk (bytes): the packet bytes
+    Returns:
+        bytes: reduced chunk with removed channel bytes
+    """
+    # pylint: disable=R0201
+    samples_nr = (struct.unpack_from("<i", memoryview(chunk)))[0]
+    return chunk[4:], samples_nr
+
+class Header:
+    """Read header elements from DeweSoft
+
+    See: dewenet_data.py for more information
+
+    Attributes:
+        packet_size (int): Size in bytes of the whole packet
+        packet_type (int): Always 0 = data packet
+        samples_sync_in_packet (int): number of samples in packet
+        samples_acquired_so_far (long): number of acquired samples
+        time_of_packet_in_sec (float): timestamp of the packet
+    """
+
+    def __init__(self):
+        """Constructor
+        """
+        self.packet_size = None
+        self.packet_type = None
+        self.samples_sync_in_packet = None
+        self.samples_acquired_so_far = None
+        self.time_of_packet_in_sec = None
+
+    def log_format(self):
+        """Return a log formated string of attributes.
+
+        Returns:
+            str: formatted string of header elements
+        """
+        outstr = ("\tPacket Size: {}"
+                  "\tSync. Samples in Packet: {}"
+                  "\tTime of Packet: {}"
+                  "\tAbs. No of Packets: {}"
+                  "\tPacket Type: {}".format(
+                      self.packet_size, self.samples_sync_in_packet,
+                      self.time_of_packet_in_sec,
+                      self.samples_acquired_so_far, self.packet_type))
+        return outstr
+
+    @staticmethod
+    def from_bytes(chunk):
+        """Generate a header element from a byte string
+
+        Args:
+            chunk (bytes): Read bytes from DeweSoft
+        Returns:
+            bytes: reduced chunk with removed header bytes
+            Header: generated header containing read elements
+        """
+        packet_header = struct.unpack_from("<iiiqd",
+                                           memoryview(chunk))
+        header = Header()
+        header.packet_size = packet_header[0]
+        header.packet_type = packet_header[1]  # Always 0
+        header.samples_sync_in_packet = packet_header[2]
+        header.samples_acquired_so_far = packet_header[3]
+        header.time_of_packet_in_sec = packet_header[4] * 86400
+
+        return chunk[28:], header

--- a/Lib/svpelab/dewenetcontroller/dewenetcontroller.py
+++ b/Lib/svpelab/dewenetcontroller/dewenetcontroller.py
@@ -1,0 +1,358 @@
+"""
+Copyright (c) 2018, Austrian Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the Austrian Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+
+
+
+
+
+
+""" Main module for the communication with the DeweSoft over the NET interface
+
+The dewenetcontroller is used to watch the channels of a DeweSoft
+measurement unit.
+
+TODO: implement fallback solution if DeweSoft can't connect to the python
+server.
+
+TODO: start dewesoft if it isn't running and the dewenetcontroller connects to
+    localhost
+"""
+
+import logging
+import time
+import datetime
+
+import numpy as np
+
+from .dewenet_client import DeweNetControllerClient
+from .dewenet_server import DeweNetControllerServer
+from .dewenet_data import DeweChannel
+
+logging.basicConfig(level=logging.INFO)
+
+
+class DeweNetController(object):
+    """ Main class for communication with DeweSoft measurement system
+
+    Attributes:
+        _logger: Logger of the Class
+        _client (DeweNetControllerClient): Client for remote control the
+            DeweSoft system
+        _server (DeweNetControllerServer): Server for receiving measurement
+            values from the DeweSoft system.
+        _setup_filename (str): Path and name of the setup file that is stored
+            on the measurement system
+        _storage_filename (str): Path and name of the storage file in the
+            DeweSoft measurement system
+
+        samplerate (int): Used sample rate read from DeweSoft (in Hertz)
+        starttime (datetime): Start time of the measurement. All measurement
+            timestamps are indexes using the samplerate and the starttime to
+            get a real timestamp
+        stoptime (datetime): Time of the stopped measurement
+        is_running (bool): State variable for a running instance/connection
+            with the DeweSoft
+
+        _channels (dict): Dictionary of channels to be watched with the name of
+            the channel as key.
+    """
+
+    def __init__(self, setup_filename=None, storage_filename=None, logger=None, debug = False):
+        """Constructor
+
+        Args:
+            setup_filename (str): File name and path of the DeweSoft setup file
+                stored on the DeweSoft host
+            storage_filename (str): File name and path of the DeweSoft
+                measurement file stored on the DeweSoft host
+            logger (logging.logger): optional logger of the class.
+        """
+
+        self._timecount_ = 0.0
+
+
+
+
+        self._logger = logger or logging.getLogger(__name__)
+
+        if debug:
+            self._logger.setLevel(logging.DEBUG)
+
+        self._logger.debug("Init DeweNetController")
+
+        self._client = DeweNetControllerClient(logger=self._logger)
+        self._server = None
+
+        if setup_filename and setup_filename.endswith(".d7s"):
+            self._setup_filename = setup_filename
+        else:
+            self._logger.warn("No setup file defined")
+            self._setup_filename = None
+
+        if storage_filename and storage_filename.endswith(".d7d"):
+            self._storage_filename = storage_filename
+        else:
+            self._logger.warn("No storage file defined")
+            self._storage_filename = None
+
+        self.samplerate = None
+        self.starttime = None
+        self.stoptime = None
+        self.is_running = False
+
+        self._channels = dict()
+
+        self.dewe_interface_version = None
+        self.dewe_version = None
+
+    def get_dewe_information(self):
+        return 'DEWESoft %s (Interface Version: %s)' % (self.dewe_version, self.dewe_interface_version)
+
+
+    def connect_to_dewe(self, dewe_ip='127.0.0.1', dewe_port=8999,
+                        client_server_ip="", client_server_port=9000,
+                        list_of_channels=None, samplerate = None,
+                        read_only_single_values = False, controlMode = False):
+        """Connect to the DeweSoft instances.
+
+        The instance must already be running on the host.
+
+        Args:
+            dewe_ip (str): IP address of the running DeweSoft to be controlled.
+            dewe_port (int): Port of the running DeweSoft to be controlled.
+            client_server_ip (str): Network interface of the server that will be
+                opened. If an empty string is set, than from any computer the
+                server is reachable.
+            client_server_port (int): Port of the server that will be opened to
+                receive measurement data.
+            list_of_channels (list): List of str. A list of channel names, that
+                the client should listen. If None is given than all available
+                channels of the DeweSoft measurement will be used.
+
+        Note:
+            TODO - start DeweSoft program, if it isn't running exec()
+        """
+
+        self._logger.info("Start DeweNetClient ({}: {})".format(dewe_ip,
+                                                                dewe_port))
+        self.dewe_interface_version, self.dewe_version = self._client.connect_to_dewe(dewe_ip, dewe_port)
+        time.sleep(0.2)
+
+        if self._client.dewe_is_measuring():
+            self._client.dewe_stop()
+
+        #self._client.dewe_stop()
+
+        if self._setup_filename:
+            self._logger.info(
+                "Load Setup file: {}".format(self._setup_filename))
+            self._client.dewe_load_setupfile(self._setup_filename)
+        else:
+            self._logger.info(
+                "Load no Setup file. Use already running DeweSoft Setup ")
+
+        self._client.dewe_list_used_channels()
+
+        self._logger.info(
+            "Available Channels {}".format(
+                [ch_info.name for ch_info in
+                 self._client.available_channels.values()]))
+
+        if not list_of_channels:
+            # use all available channels if no definition is given in the args
+            list_of_channels = [ch_info.name for ch_info in
+                                self._client.available_channels.values()]
+
+        for element in list_of_channels:
+            if element in self._client.available_channels:
+                channel = DeweChannel(self._client.available_channels[element])
+                channel.update_handler = self._handling_value_updates
+                self._channels[element] = {'ch': channel,
+                                           'handlers': list()}
+
+        self._logger.info("Watch Channels: {}".format(self._channels.keys()))
+
+        list_server_channels = [ch['ch'] for ch in self._channels.values()]
+        self._logger.info(
+            "Start DeweNetControllerServer ({})".format(client_server_port))
+        self._server = DeweNetControllerServer(list_server_channels,
+                                               read_only_single_values = read_only_single_values,
+                                               server_ip=client_server_ip,
+                                               tcp_port=client_server_port,
+                                               logger=self._logger)
+        self._server.start()
+
+        self._logger.info("Start Transfer")
+        if not samplerate:
+            self.samplerate = self._client.dewe_get_samplerate()
+        else:
+            try:
+                try:
+                    self._client.dewe_set_mode(1)
+                except:
+                    pass
+                self.samplerate = self._client.dewe_set_samplerate(samplerate)
+            except:
+                self._logger.error("Failed to set custom samplerate")
+                raise
+
+        self._server.samplerate = self.samplerate
+        channel_list = [ch for ch in self._channels.keys()]
+        time.sleep(0.2)
+        self._client.dewe_init_start_transfer(client_server_port, channel_list)
+
+
+    def stop_dewe_measurement(self):
+        if self._client:
+            self._client.dewe_stop()
+            self._client.dewe_stop_transfer()
+            self.is_running = False
+
+
+    def start_dewe_measurement(self):
+        """Start the measurement of the DeweSoft system.
+
+        This will start an acquisition with or without storage of the DeweSoft
+        measuremnt unit.
+        """
+
+        if self._storage_filename:
+            self._logger.info(
+                "Start Acquisition and Storage at {}.".format(
+                    self._storage_filename))
+            self._client.dewe_set_storing(True)
+
+            self.starttime = self._client.dewe_start_store(
+                self._storage_filename)
+        else:
+            self._logger.info("Start Acquisition only")
+            self.starttime = self._client.dewe_start_acquisition()
+
+        self._logger.info(
+            "Startup at {} with sample rate {}  Hz".format(self.starttime,
+                                                           self.samplerate))
+        self.is_running = True
+
+    def disconnect_from_dewe(self):
+        """Disconnect from the running DeweSoft measurement system.
+        """
+        if self.is_running:
+            self._logger.info("Disconnect from DeweSoft")
+            self._client.dewe_stop_transfer()
+            self.stoptime = self._client.dewe_stop()
+            self._logger.info(
+                "Stopped at {} Measurement Duration: {}".format(
+                    self.stoptime, self.stoptime - self.starttime))
+        self.close_connections()
+
+    def close_connections(self):
+        """Close all opened connections of the DewenetController"""
+        self._logger.warn("Close opened Servers and Connections")
+        if self._client:
+            self._client.disconnect_from_dewe()
+        if self._server:
+            self._server.close_server()
+        self.is_running = False
+
+    def _handling_value_updates(self, name, value, timestamp):
+        """Handling callback for channel updates
+
+        This handler will be called if a value of a channel is received. This
+        is a single instance handler for all managed channels. This method
+        will be called from the internal channel object.
+
+        It will used the registered handler in this class to inform components
+        that are using the dewenetcontroller.
+
+        Args:
+            name (str): Name of the channel
+            value (float): Value of hte measured sample
+            timestamp (float): Relative timestamp of the value in seconds since
+                start of acquisition
+        """
+        try:
+            delta = datetime.timedelta(seconds=timestamp)
+
+            timestamp = self.starttime + delta
+            for handler in self._channels[name]['handlers']:
+                handler(name, timestamp, value)
+
+        except OverflowError as ex:
+            self._logger.warn(
+                "Timestamp ({timestamp}) conversation OverflowError "
+                "for {name} {value}:".format(name=name,
+                                             value=value,
+                                             timestamp=timestamp),
+                ex)
+
+    def add_update_value_handler(self, function, channels=None):
+        """Add an update handler to the Dewenet Controller.
+
+        The update handler will be called if a channel received an update
+
+        Args:
+            function (function): Update handler to be registered
+                The update handler must have following ordered arguments:
+                    name (str): Name of the channel
+                    timestamp (datetime): Time of the measured sample
+                    value (float, int): Value of the sample
+            channels (list): A list of channel names. The handler will be
+                registered to the given channels. If None is set to the list,
+                than the handler method will be registered to all available
+                channels.
+        """
+
+        if not channels:
+            channels = self._channels.keys()
+        for channel in channels:
+            if channel in self._channels:
+                self._channels[channel]['handlers'].append(function)
+
+    def get_watched_channel(self, channel_name):
+        """Get a watched channel by name:
+
+        Args:
+            channel_name (str): Name of the DeweSoft channel.
+
+        Returns:
+            DeweChannel: The requested channel.
+        """
+        return self._channels[channel_name]['ch']
+
+    @property
+    def watched_channels(self):
+        """List of watched channels
+
+        Returns
+            list: list of str containing the names of all watched channels.
+        """
+        return self._channels.keys()


### PR DESCRIPTION
This commit brings with it a Python 2/3 package that can be used to
communicate with DEWESoft's Net interface as well as an SVP-DAS
abstraction enabling the use of "any" DEWESoft device (Provided it
supports the NET interface) as a DAS in SVP

- dewecontroller/
Houses the main communication and data processing system
Please note that this package will pull up an additional thread
to parse the data received from DEWESoft

Due to the nature of communication, this package is limited to
1 datapoint every 250ms. It does support waveform capture for more
accurate and detailed acquisition.

