### PR TITLE
Update SunSpec DER implementation to support TLS options

### DIFF
--- a/Lib/svpelab/der_sunspec.py
+++ b/Lib/svpelab/der_sunspec.py
@@ -65,6 +65,16 @@ def params(info, group_name):
     info.param(pname('ipaddr'), label='IP Address', default='192.168.0.170', active=pname('ifc_type'),
                active_value=[client.TCP])
     info.param(pname('ipport'), label='IP Port', default=502, active=pname('ifc_type'), active_value=[client.TCP])
+    info.param(pname('tls'), label='TLS Client', default=False, active=pname('ifc_type'), active_value=[client.TCP],
+               desc='Enable TLS (Modbus/TCP Security).')
+    info.param(pname('cafile'), label='CA Certificate', default=None, active=pname('ifc_type'), active_value=[client.TCP],
+               desc='Path to certificate authority (CA) certificate to use for validating server certificates.')
+    info.param(pname('certfile'), label='Client TLS Certificate', default=None, active=pname('ifc_type'), active_value=[client.TCP],
+               desc='Path to client TLS certificate to use for client authentication.')
+    info.param(pname('keyfile'), label='Client TLS Key', default=None, active=pname('ifc_type'), active_value=[client.TCP],
+               desc='Path to client TLS key to use for client authentication.')
+    info.param(pname('insecure_skip_tls_verify'), label='Skip TLS Verification', default=False, active=pname('ifc_type'), active_value=[client.TCP],
+               desc='Skip Verification of Server TLS Certificate.')
     # Mapped parameters
     info.param(pname('map_name'), label='Map File', default='mbmap.xml',active=pname('ifc_type'),
                active_value=[client.MAPPED], ptype=script.PTYPE_FILE)
@@ -159,10 +169,16 @@ class DER(der.DER):
         parity = self.param_value('parity')
         ipaddr = self.param_value('ipaddr')
         ipport = self.param_value('ipport')
+        tls = self.param_value('tls')
+        cafile = self.param_value('cafile')
+        certfile = self.param_value('certfile')
+        keyfile = self.param_value('keyfile')
+        skip_verify = self.param_value('insecure_skip_tls_verify')
         slave_id = self.param_value('slave_id')
 
         self.inv = client.SunSpecClientDevice(ifc_type, slave_id=slave_id, name=ifc_name, baudrate=baudrate,
-                                              parity=parity, ipaddr=ipaddr, ipport=ipport)
+                                              parity=parity, ipaddr=ipaddr, ipport=ipport,
+                                              tls=tls, cafile=cafile, certfile=certfile, keyfile=keyfile, insecure_skip_tls_verify=skip_verify)
 
     def close(self):
         if self.inv is not None:


### PR DESCRIPTION
SunSpec client TLS options were added to [sunspec/pysunspec](https://github.com/sunspec/pysunspec) in PR sunspec/pysunspec#97.